### PR TITLE
DAF-4480: LSM対応後のインターネット切断の検知

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "shogo4405/Logboard" "2.3.0"

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "HaishinKit", targets: ["HaishinKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/shogo4405/Logboard.git", from: "2.3.0")
+        .package(url: "https://github.com/shogo4405/Logboard.git", "2.3.0"..<"2.4.0")
     ],
     targets: [
         .target(name: "SwiftPMSupport"),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "HaishinKit", targets: ["HaishinKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/shogo4405/Logboard.git", "2.3.0"..<"2.4.0")
+        .package(url: "https://github.com/shogo4405/Logboard.git", from: "2.3.0")
     ],
     targets: [
         .target(name: "SwiftPMSupport"),

--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -176,6 +176,7 @@ open class NetSocket: NSObject {
 extension NetSocket: StreamDelegate {
     // MARK: StreamDelegate
     public func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
+        print("NetSocketStream eventCode: \(eventCode)")
         switch eventCode {
         //  1 = 1 << 0
         case .openCompleted:

--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -176,7 +176,7 @@ open class NetSocket: NSObject {
 extension NetSocket: StreamDelegate {
     // MARK: StreamDelegate
     public func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
-        print("NetSocketStream eventCode: \(eventCode)")
+//        print("NetSocketStream eventCode: \(eventCode), timeout: \(timeout), connected: \(connected), windowSizeC: \(windowSizeC), outputBufferSize: \(outputBufferSize), queueBytesOut: \(queueBytesOut.value)")
         switch eventCode {
         //  1 = 1 << 0
         case .openCompleted:

--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -26,6 +26,9 @@ open class NetSocket: NSObject {
     public private(set) var totalBytesOut: Atomic<Int64> = .init(0)
     /// Specifies  statistics of total outgoing queued bytes.
     public private(set) var queueBytesOut: Atomic<Int64> = .init(0)
+    
+    private var streamTimer: Timer?
+    private let streamTimeout: Double = 5 // sec
 
     var inputStream: InputStream? {
         didSet {
@@ -171,12 +174,24 @@ open class NetSocket: NSObject {
             outputBuffer.skip(length)
         }
     }
+    
+    private func setStreamTimer() {
+//        streamTimer?.invalidate()
+//        streamTimer = nil
+        print("daf-4480 timer set")
+        streamTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false, block: { [weak self] timer in
+            self?.deinitConnection(isDisconnected: true)
+            print("daf-4480 timer executed")
+            timer.invalidate()
+        })
+    }
 }
 
 extension NetSocket: StreamDelegate {
     // MARK: StreamDelegate
     public func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
 //        print("NetSocketStream eventCode: \(eventCode), timeout: \(timeout), connected: \(connected), windowSizeC: \(windowSizeC), outputBufferSize: \(outputBufferSize), queueBytesOut: \(queueBytesOut.value)")
+        setStreamTimer()
         switch eventCode {
         //  1 = 1 << 0
         case .openCompleted:

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -26,6 +26,8 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
             }
         }
     }
+    private var streamTimer: Timer?
+    private let streamTimeout: Double = 5 // sec
 
     override var totalBytesIn: Atomic<Int64> {
         didSet {
@@ -51,6 +53,7 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
 
     @discardableResult
     func doOutput(chunk: RTMPChunk) -> Int {
+        setStreamTimer()
         setOutputAvailability()
         let chunks: [Data] = chunk.split(chunkSizeS)
         for i in 0..<chunks.count - 1 {
@@ -69,6 +72,18 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
         } else {
             isOutputUnavailable = true
         }
+    }
+    
+    private func setStreamTimer() {
+        print("daf-4480 queueBytesOut: \(queueBytesOut.value)")
+//        streamTimer?.invalidate()
+//        streamTimer = nil
+//        print("daf-4480 timer set")
+//        streamTimer = Timer.scheduledTimer(withTimeInterval: streamTimeout, repeats: false, block: { [weak self] timer in
+//            self?.deinitConnection(isDisconnected: true)
+//            timer.invalidate()
+//            print("daf-4480 timer executed")
+//        })
     }
 
     override func listen() {
@@ -110,6 +125,7 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
     }
 
     override func deinitConnection(isDisconnected: Bool) {
+        print("daf-4480 deinitConnection. isDisconnected: \(isDisconnected), readyState: \(readyState)")
         if isDisconnected {
             let data: ASObject = (readyState == .handshakeDone) ?
                 RTMPConnection.Code.connectClosed.data("") : RTMPConnection.Code.connectFailed.data("")

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -70,7 +70,6 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
         let streamTimeOut = 8
         guard let lastOutputStreamTime else { return }
         let difference = Int(Date().timeIntervalSinceReferenceDate - lastOutputStreamTime.timeIntervalSinceReferenceDate)
-        print("daf-4480 checkStream difference: \(difference)")
         if difference >= streamTimeOut {
             self.lastOutputStreamTime = nil
             deinitConnection(isDisconnected: true)

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -53,9 +53,10 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
 
     @discardableResult
     func doOutput(chunk: RTMPChunk) -> Int {
-        setStreamTimer()
+        //setStreamTimer()
         setOutputAvailability()
         let chunks: [Data] = chunk.split(chunkSizeS)
+        print("daf-4480 doOutput chunk: \(chunk.debugDescription)")
         for i in 0..<chunks.count - 1 {
             doOutput(data: chunks[i])
         }

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -26,8 +26,6 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
             }
         }
     }
-    private var streamTimer: Timer?
-    private let streamTimeout: Double = 5 // sec
 
     override var totalBytesIn: Atomic<Int64> {
         didSet {
@@ -53,10 +51,8 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
 
     @discardableResult
     func doOutput(chunk: RTMPChunk) -> Int {
-        //setStreamTimer()
         setOutputAvailability()
         let chunks: [Data] = chunk.split(chunkSizeS)
-        print("daf-4480 doOutput chunk: \(chunk.debugDescription)")
         for i in 0..<chunks.count - 1 {
             doOutput(data: chunks[i])
         }
@@ -73,18 +69,6 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
         } else {
             isOutputUnavailable = true
         }
-    }
-    
-    private func setStreamTimer() {
-        print("daf-4480 queueBytesOut: \(queueBytesOut.value)")
-//        streamTimer?.invalidate()
-//        streamTimer = nil
-//        print("daf-4480 timer set")
-//        streamTimer = Timer.scheduledTimer(withTimeInterval: streamTimeout, repeats: false, block: { [weak self] timer in
-//            self?.deinitConnection(isDisconnected: true)
-//            timer.invalidate()
-//            print("daf-4480 timer executed")
-//        })
     }
 
     override func listen() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,9 +13,11 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
-desc "[CI] Review PullRequest."
-lane :review do
-  spm
-  carthage(use_xcframeworks: true) if Helper.is_ci?
-  scan(scheme: 'Tests')
+platform :ios do
+  desc "[CI] Review PullRequest."
+  lane :review do
+    spm
+    carthage(use_xcframeworks: true) if Helper.is_ci?
+    scan(scheme: 'Tests')
+  end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,9 @@
 desc "[CI] Review PullRequest."
 lane :review do
   spm
-  carthage(use_xcframeworks: true, platform: "iOS") if Helper.is_ci?
+  carthage(
+    use_xcframeworks: true,
+    platform: 'iOS'
+  ) if Helper.is_ci?
   scan(scheme: 'Tests')
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,11 +13,9 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
-platform :ios do
-  desc "[CI] Review PullRequest."
-  lane :review do
-    spm
-    carthage(use_xcframeworks: true) if Helper.is_ci?
-    scan(scheme: 'Tests')
-  end
+desc "[CI] Review PullRequest."
+lane :review do
+  spm
+  carthage(use_xcframeworks: true, platform: "iOS") if Helper.is_ci?
+  scan(scheme: 'Tests')
 end


### PR DESCRIPTION
## Summary

LSM経由の配信になったことにより、インターネット切断が起きた際にストリームエラーが飛んでこない状態になった。
インターネット切断を検知するために、ストリームが一定時間（８秒間）飛んでこない場合に、インターネット接続がなくなったと検知し、再接続を試みる実装とした。

８秒間に設定した理由は、インターネット接続が弱くなるとストリームが数秒間途切れることがあるが、３G回線で最大で６秒ほどだったことから、８秒ストリームが途切れた時にインターネット接続がなくなったと判断するようにした。

こちらの修正を入れることで、アーカイブ分割も起きないようになった。

## Ticket
https://dw-ml-nfc.atlassian.net/browse/DAF-4480

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

https://github.com/dwango-nfc/HaishinKit.swift/assets/112542554/4c533568-f969-4235-b46f-a867f8a494da

[0:03] インターネット切断

[0:07] ネットワーク不安定トーストが表示されて、８秒後にローディング画面となる。

[0:14] 視聴アプリが黒画面となる

[0:22] インターネット再接続する

[0:45] 視聴アプリで映像が復帰する。アーカイブ分割も起きない
