### PR TITLE
Revert "DAF-4480: LSM対応後のインターネット切断の検知"

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "shogo4405/Logboard" "2.3.0"

--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -58,10 +58,6 @@ open class NetSocket: NSObject {
     private lazy var buffer = [UInt8](repeating: 0, count: windowSizeC)
     private lazy var outputBuffer: DataBuffer = .init(capacity: outputBufferSize)
     private lazy var outputQueue: DispatchQueue = .init(label: "com.haishinkit.HaishinKit.NetSocket.output", qos: qualityOfService)
-    
-    // Detect network disconnection after LSM
-    // https://dw-ml-nfc.atlassian.net/browse/DAF-4480
-    var lastOutputStreamTime: Date?
 
     deinit {
         inputStream?.delegate = nil
@@ -180,11 +176,6 @@ open class NetSocket: NSObject {
 extension NetSocket: StreamDelegate {
     // MARK: StreamDelegate
     public func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
-        // Detect network disconnection after LSM
-        // https://dw-ml-nfc.atlassian.net/browse/DAF-4480
-        if aStream is OutputStream {
-            lastOutputStreamTime = Date()
-        }
         switch eventCode {
         //  1 = 1 << 0
         case .openCompleted:

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -51,7 +51,6 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
 
     @discardableResult
     func doOutput(chunk: RTMPChunk) -> Int {
-        checkStreamTimeOut()
         setOutputAvailability()
         let chunks: [Data] = chunk.split(chunkSizeS)
         for i in 0..<chunks.count - 1 {
@@ -62,18 +61,6 @@ final class RTMPSocket: NetSocket, RTMPSocketCompatible {
             logger.trace(chunk)
         }
         return chunk.message!.length
-    }
-    
-    // Detect network disconnection after LSM
-    // https://dw-ml-nfc.atlassian.net/browse/DAF-4480
-    private func checkStreamTimeOut() {
-        let streamTimeOut = 8
-        guard let lastOutputStreamTime else { return }
-        let difference = Int(Date().timeIntervalSinceReferenceDate - lastOutputStreamTime.timeIntervalSinceReferenceDate)
-        if difference >= streamTimeOut {
-            self.lastOutputStreamTime = nil
-            deinitConnection(isDisconnected: true)
-        }
     }
     
     private func setOutputAvailability() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,9 +16,6 @@
 desc "[CI] Review PullRequest."
 lane :review do
   spm
-  carthage(
-    use_xcframeworks: true,
-    platform: 'iOS'
-  ) if Helper.is_ci?
+  carthage(use_xcframeworks: true) if Helper.is_ci?
   scan(scheme: 'Tests')
 end


### PR DESCRIPTION
こちらのPRはLSM配信のインターネット切断の検知のための実装だったが、Webのチューニングにより不必要になったためrevert